### PR TITLE
added auth0_domain and auth0_client_id initial todo-app

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -47,8 +47,8 @@ function MyApp({ Component, pageProps, authDomain, authClient }: AppPropsWithLay
 }
 
 MyApp.getInitialProps = async (appContext: AppContext) => {
-  const authDomain = process.env.NEXT_PUBLIC_AUTH_DOMAIN || process.env.AUTH0_DOMAIN;
-  const authClient = process.env.NEXT_PUBLIC_AUTH_CLIENT || process.env.AUTH0_CLIENT_ID;
+  const authDomain = process.env.NEXT_PUBLIC_AUTH_DOMAIN || process.env.AUTH0_DOMAIN as string;
+  const authClient = process.env.NEXT_PUBLIC_AUTH_CLIENT || process.env.AUTH0_CLIENT_ID as string;
 
   if (!authDomain) {
     throw new Error('Auth domain not found');

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,32 +1,30 @@
-import '../styles/globals.css'
-import React from 'react'
-import { ErrorBoundary } from 'react-error-boundary'
-import { ErrorFallback } from '../components/errors'
-import { ConvexReactClient } from 'convex/react'
-import { ConvexProviderWithAuth0 } from 'convex/react-auth0'
-import { Auth0Provider } from '@auth0/auth0-react'
-import type { ReactElement, ReactNode } from 'react'
-import type { NextPage } from 'next'
-import type { AppProps } from 'next/app'
+import '../styles/globals.css';
+import React from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { ErrorFallback } from '../components/errors';
+import { ConvexReactClient } from 'convex/react';
+import { ConvexProviderWithAuth0 } from 'convex/react-auth0';
+import { Auth0Provider } from '@auth0/auth0-react';
+import type { ReactElement, ReactNode } from 'react';
+import type { NextPage } from 'next';
+import type { AppProps, AppContext } from 'next/app';
+import App from 'next/app';
 
 export type NextPageWithLayout<P = unknown, IP = P> = NextPage<P, IP> & {
-  getLayout?: (page: ReactElement) => ReactNode
-}
+  getLayout?: (page: ReactElement) => ReactNode;
+};
 
 type AppPropsWithLayout = AppProps & {
-  Component: NextPageWithLayout
-}
+  Component: NextPageWithLayout;
+  authDomain: string;
+  authClient: string;
+};
 
-const address = process.env.NEXT_PUBLIC_CONVEX_URL
-if (!address) throw new Error('Convex URL not found')
-const convex = new ConvexReactClient(address)
+const address = process.env.NEXT_PUBLIC_CONVEX_URL;
+if (!address) throw new Error('Convex URL not found');
+const convex = new ConvexReactClient(address);
 
-const authDomain = process.env.NEXT_PUBLIC_AUTH_DOMAIN as string
-const authClient = process.env.NEXT_PUBLIC_AUTH_CLIENT as string
-if (!authDomain) throw new Error('Auth domain not found')
-if (!authClient) throw new Error('Auth client not found')
-
-function MyApp({ Component, pageProps }: AppPropsWithLayout) {
+function MyApp({ Component, pageProps, authDomain, authClient }: AppPropsWithLayout) {
   return (
     <>
       <ErrorBoundary FallbackComponent={ErrorFallback}>
@@ -34,10 +32,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
           domain={authDomain}
           clientId={authClient}
           authorizationParams={{
-            redirect_uri:
-              typeof window === 'undefined'
-                ? undefined
-                : window.location.origin,
+            redirect_uri: typeof window === 'undefined' ? undefined : window.location.origin,
           }}
           useRefreshTokens={true}
           cacheLocation="localstorage"
@@ -48,7 +43,21 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
         </Auth0Provider>
       </ErrorBoundary>
     </>
-  )
+  );
 }
 
-export default MyApp
+MyApp.getInitialProps = async (appContext: AppContext) => {
+  const authDomain = process.env.NEXT_PUBLIC_AUTH_DOMAIN || process.env.AUTH0_DOMAIN;
+  const authClient = process.env.NEXT_PUBLIC_AUTH_CLIENT || process.env.AUTH0_CLIENT_ID;
+
+  if (!authDomain) {
+    throw new Error('Auth domain not found');
+  }
+  if (!authClient) {
+    throw new Error('Auth client not found');
+  }
+  const appProps = await App.getInitialProps(appContext);
+  return { ...appProps, authDomain, authClient };
+};
+
+export default MyApp;


### PR DESCRIPTION
<!-- Describe your PR here. -->

when you first install the app from the repo as in the instructions without any modifications `npm run dev` 
const authDomain = process.env.NEXT_PUBLIC_AUTH_DOMAIN;
const authClient = process.env.NEXT_PUBLIC_AUTH_CLIENT;
in _app.tsx

Is just missing:
process.env.AUTH0_DOMAIN
process.env.AUTH0_CLIENT_ID

and it throws an error immediately if you have it or not I just separated it in the _app.tsx so you get the todo-app instead of an error page when you've set it up correctly.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore. 👍
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
